### PR TITLE
align multi-line code

### DIFF
--- a/themes/marblerun/assets/scss/_code.scss
+++ b/themes/marblerun/assets/scss/_code.scss
@@ -32,7 +32,7 @@ kbd {
 
 // Blocks of code
 pre {
-  display: block;
+  display: flex;
   @include font-size($code-font-size);
   color: $pre-color;
 

--- a/themes/marblerun/assets/scss/_main.scss
+++ b/themes/marblerun/assets/scss/_main.scss
@@ -11,7 +11,7 @@ nav {
 }
 
 pre {
-  padding: 16px;
+  padding: 14px;
   border-radius: $border-radius;
 }
 


### PR DESCRIPTION
Changed display type of multi-line code blocks. 
Also adjusted the padding, so the new box size is more inline with the old one. 