### PR TITLE
Add "note" and "alert" boxes to docs

### DIFF
--- a/content/docs/getting-started/coordinator.md
+++ b/content/docs/getting-started/coordinator.md
@@ -127,9 +127,11 @@ sudo chmod +x /usr/local/bin/era
 era -c coordinator-era.json -h $MARBLERUN -o marblerun.crt
 ```
 
-*Note: On machines running Ubuntu, ~/.local/bin is only added to PATH when the directory exists when initializing your bash environment during login. You might need to re-login after creating the directory. Also, non-default shells such as `zsh` do not add this path by default. Therefore, if you receive `command not found: era` as an error message for a local user installation, either make sure ~/.local/bin was added to your PATH successfully or simply use the machine-wide installation method.*
+{{<note>}}
+On Ubuntu, `~/.local/bin` is only added to PATH when the directory exists when initializing your bash environment during login. You might need to re-login after creating the directory. Also, non-default shells such as `zsh` do not add this path by default. Therefore, if you receive `command not found: era` as an error message for a local user installation, either make sure `~/.local/bin` was added to your PATH successfully or simply use the machine-wide installation method.
+{{</note>}}
 
-Note that `coordinator-era.json` contains the *Packages* information for the Coordinator. For our testing image this can be pulled from our GitHub releases:
+The file `coordinator-era.json` contains the *Packages* information for the Coordinator. For our testing image this can be pulled from our GitHub releases:
 
 ```bash
 wget https://github.com/edgelesssys/marblerun/releases/latest/download/coordinator-era.json

--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -7,7 +7,6 @@ weight: 1
 
 # Quickstart
 
-
 Set up a Kubernetes cluster and install `kubectl`. Probably the easiest way to get started is to run Kubernetes on your local machine using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/). Another easy way is to use [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal), which offers SGX-enabled nodes.
 
 In this guide will show you how to deploy and verify the [Confidential Emoji.voto](https://github.com/edgelesssys/emojivoto) application, an microservice that allows users to vote for their favorite emoji, and tracks votes received on a leaderboard.
@@ -63,7 +62,7 @@ kubectl -n marblerun port-forward svc/coordinator-client-api 25555:25555 --addre
 export MARBLERUN=localhost:25555
 ```
 
-Verify the Quote and get the Coordinator's Root-Certificate. The SGX Quote proofs the integrity of the coordinator pod. Marblerun returns a certificate as result and stores it as marblerun.cert in your current directory. The Certificate is bound to the Quote and can be used for future verification. Since we are not using SGX hardware in this case, the quote is omitted by marblerun.
+Verify the quote and get the Coordinator's root certificate. The SGX quote proves the integrity of the coordinator pod. Marblerun returns a certificate as result and stores it as `marblerun.cert` in your current directory. The certificate is bound to the quote and can be used for future verification. Since we are not using SGX hardware in this case, the quote is omitted by marblerun.
 
 ```bash
 marblerun certificate root $MARBLERUN -o marblerun.crt --insecure
@@ -89,8 +88,7 @@ Make the voting frontend reachable for with port-forwarding:
 sudo kubectl -n emojivoto port-forward svc/web-svc 443:443 --address 0.0.0.0
 ```
 
-Install Marblerun-Certificate in your browser
-* **Warning** Be careful when adding certificates to your browser. We only do this temporarily for the sake of this demo. Make sure you don't use your browser for other activities in the meanwhile and remove the certificate afterward.
+Install Marblerun's certificate in your browser
 * Chrome:
     * Go to <chrome://settings/security>
     * Go to `"Manage certificates" > "Import..."`
@@ -99,6 +97,10 @@ Install Marblerun-Certificate in your browser
     * Go to <about:preferences#privacy>
     * Go to `Certificates: View Certificates > Authorities`
     * Go to `Import...` and select the `marblerun.crt` of the previous step
+
+{{<alert>}}
+Be careful when adding certificates to your browser. Make sure to remove the certificate again before browsing to any other website.
+{{</alert>}}
 
 Browse to [https://localhost](https://localhost).
 
@@ -146,7 +148,7 @@ Get the Coordinator's address and set the DNS. Check our docs on [how to expose 
 export MARBLERUN=mycluster.uksouth.cloudapp.azure.com
 ```
 
-Verify the Quote and get the Coordinator's Root-Certificate. The SGX Quote proofs the integrity of the coordinator pod. Marblerun returns a certificate as result and stores it as marblerun.cert in your current directory. The Certificate is bound to the Quote and can be used for future verification.
+Verify the quote and get the Coordinator's root certificate. The SGX quote proves the integrity of the coordinator pod. Marblerun returns a certificate as result and stores it as `marblerun.cert` in your current directory. The certificate is bound to the quote and can be used for future verification.
 
 ```bash
 marblerun certificate root $MARBLERUN -o marblerun.crt
@@ -174,8 +176,7 @@ helm install -f ./kubernetes/sgx_values.yaml emojivoto ./kubernetes --create-nam
     * Get the public IP with: `kubectl -n emojivoto get svc web-svc -o wide`
     * If you're using ingress/gateway-controllers make sure you enable [SNI-passthrough]({{< ref "docs/tasks/deploy.md#ingressgateway-configuration" >}})
 
-* Install Marblerun-Certificate in your browser
-    * **Warning** Be careful when adding certificates to your browser. We only do this temporarily for the sake of this demo. Make sure you don't use your browser for other activities in the meanwhile and remove the certificate afterward.
+* Install Marblerun's certificate in your browser
     * Chrome:
         * Go to <chrome://settings/security>
         * Go to `"Manage certificates" > "Import..."`
@@ -185,4 +186,8 @@ helm install -f ./kubernetes/sgx_values.yaml emojivoto ./kubernetes --create-nam
         * Go to `Certificates: View Certificates > Authorities`
         * Go to `Import...` and select the `marblerun.crt` of the previous step
 
-* Browse to [https://your-clusters-domain:port](#).
+{{<alert>}}
+Be careful when adding certificates to your browser. Make sure to remove the certificate again before browsing to any other website.
+{{</alert>}}
+
+* Browse to `https://your-clusters-domain:port`.

--- a/content/docs/tasks/deploy.md
+++ b/content/docs/tasks/deploy.md
@@ -16,7 +16,9 @@ This article assumes that you have an existing Kubernetes cluster. Currently, th
 * [Equinix](https://metal.equinix.com/product/features/) Bare Metal Servers
 * Alternatively, you can deploy the steps with [minikube](https://minikube.sigs.k8s.io/docs/start/)
 
-*Note that you need DCAP infrastructure in place for remote attestation to work. At the time of writing only Azure provided a public DCAP service in their data-centers. You can run Marblerun in simulation mode which omits remote attestation procedures and returns an empty quote on the Client API. If you're running your own data-center, you can read more about setting up DCAP [in the Intel SGX development articles](https://software.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).*
+{{<note>}}
+A working SGX DCAP environment is required for Marblerun to work. If you're not running in Azure, you'll likely need to set up your environment according to this [guide](https://software.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html). Alternatively, for testing, you can install Marblerun in simulation mode with `--simulation`.
+{{</note>}}
 
 ## Install with the Marblerun CLI
 

--- a/content/docs/tasks/set-manifest.md
+++ b/content/docs/tasks/set-manifest.md
@@ -95,4 +95,6 @@ If the Manifest contains a `RecoveryKeys` entry, you will receive a JSON reply i
 
 `{"EncryptionKey":"[base64]"}`
 
-**It is important that you keep this value stored somewhere safe. Without it, you will not be able to perform a recovery step in case the SGX seal key changed.**
+{{<alert>}}
+It is important that you keep this value stored somewhere safe. Without it, you will not be able to perform a recovery step in case the SGX seal key changed.
+{{<alert>}}

--- a/content/docs/tasks/updates.md
+++ b/content/docs/tasks/updates.md
@@ -40,9 +40,9 @@ If the Coordinator version update also affects the data plane or the Marble boot
 kubectl rollout restart deployment your_deployment_name
 ```
 
-**Note:** when updating the Coordinator image, you need to be careful about your client's configuration.
-If you specified a `UniqueID`, your clients won't accept the new Coordinator version.
-See our [remarks on Manifest values](#manifest-values) for more information.
+{{<note>}}
+Updating the Coordinator image will change its `UniqueID`, but typically not its `SignerID`.
+{{</note>}}
 
 ### Updating Marbles
 

--- a/content/docs/tasks/verification.md
+++ b/content/docs/tasks/verification.md
@@ -30,7 +30,9 @@ sudo chmod +x /usr/local/bin/era
 era -c coordinator-era.json -h $MARBLERUN -output-chain marblerun-chain.pem -output-root marblerun-root.pem -output-intermediate marblerun-intermedite.pem
 ```
 
-*Note: On machines running Ubuntu, ~/.local/bin is only added to PATH when the directory exists when initializing your bash environment during login. You might need to re-login after creating the directory. Also, non-default shells such as `zsh` do not add this path by default. Therefore, if you receive `command not found: era` as an error message for a local user installation, either make sure ~/.local/bin was added to your PATH successfully or simply use the machine-wide installation method.*
+{{<note>}}
+On Ubuntu, `~/.local/bin` is only added to PATH when the directory exists when initializing your bash environment during login. You might need to re-login after creating the directory. Also, non-default shells such as `zsh` do not add this path by default. Therefore, if you receive `command not found: era` as an error message for a local user installation, either make sure `~/.local/bin` was added to your PATH successfully or simply use the machine-wide installation method.
+{{</note>}}
 
 era requires the Coordinator's UniqueID and SignerID (or MRENCLAVE and MRSIGNER in SGX terms) to verify the quote.
 In production, these would be generated when building Coordinator and distributed to your clients.

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,0 +1,6 @@
+<div class="alert">
+    <p>
+        <i class="fas fa-exclamation-triangle"></i>&nbsp;<strong>Attention</strong>
+    </p>
+    {{ .Inner | markdownify }}
+</div>

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,0 +1,6 @@
+<div class="note">
+  <p>
+    <i class="fa fa-info-circle"></i>&nbsp;<strong>Note</strong>
+  </p>
+  {{ .Inner | markdownify }}
+</div>

--- a/themes/marblerun/assets/scss/_annotations.scss
+++ b/themes/marblerun/assets/scss/_annotations.scss
@@ -1,0 +1,16 @@
+.annotation {
+    padding: 1em 1em 1em 1em;
+    margin-bottom: 1rem;
+}
+
+.note {
+    @extend .annotation;
+    border-radius: .3em;
+    border-style: solid;
+}
+
+.alert {
+    @extend .annotation;
+    background-color: black;
+    color: white;
+}

--- a/themes/marblerun/assets/scss/bootstrap.scss
+++ b/themes/marblerun/assets/scss/bootstrap.scss
@@ -42,5 +42,6 @@
 @import "spinners";
 @import "utilities";
 @import "print";
+@import "annotations";
 
 @import "main";


### PR DESCRIPTION
Used Hugo shortcodes to create "note" and "alert" boxes for the docs. Can be used as follows {{<note>}}...{{</note>}}.

Replaced all instances of "Note:" and "Warning:" in the docs with these. Are there any other places where we should use this?