### PR TITLE
Update argument order for cli recover command

### DIFF
--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -265,7 +265,7 @@ For more information about coordinator recovery see [Recovery]({{< ref "docs/tas
 **Usage**
 
 ```bash
-marblerun recover <IP:PORT> <recovery_key_decrypted> [flags]
+marblerun recover <recovery_key_decrypted> <IP:PORT> [flags]
 ```
 
 **Flags**


### PR DESCRIPTION
Update the argument order for the cli recover command to be consistent with other commands by passing the coordinators ip as the second argument