### PR TITLE
AB#695: Documentation for graphene-prepare

### DIFF
--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -40,6 +40,7 @@ Usage:
 Available Commands:
   certificate Retrieves the certificate of the Marblerun coordinator
   check       Check the status of Marbleruns control plane
+  graphene-prepare Modifies a Graphene manifest for use with Marblerun
   help        Help about any command
   install     Installs marblerun on a kubernetes cluster
   manifest    Manages manifest for the Marblerun coordinator
@@ -55,6 +56,71 @@ Flags:
 
 Use "marblerun [command] --help" for more information about a command.
 ```
+## Command `certificate`
+
+Get the root and/or intermediate certificates of the Marblerun coordinator.
+
+**Flags**
+These flags apply to all sub commands of certificate
+
+{{<table "table table-striped table-bordered">}}
+| Name, shorthand | Default | Description                                                                                                                      |
+| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| --era-config    |         | Path to remote attestation config file in json format, if none <br> provided the newest configuration will be loaded from github |
+| --help, -h      |         | help for certificate                                                                                                             |
+| --insecure, -i  |         | simulation mode                                                                                                                  |
+| --output, -o    |         | File to save the certificate to                                                                                                  |
+{{</table>}}
+
+* ### `root`
+
+  Gets the root certificate of the Marblerun coordinator.
+
+  **Usage**
+
+  ```bash
+  marblerun certificate root <IP:PORT> [flags]
+  ```
+
+* ### `intermediate`
+
+  Gets the intermediate certificate of the Marblerun coordinator.
+
+  **Usage**
+
+  ```bash
+  marblerun certificate intermediate <IP:PORT> [flags]
+  ```
+
+* ### `chain`
+
+  Gets the certificate chain of the Marblerun coordinator.
+
+  **Usage**
+
+  ```bash
+  marblerun certificate chain <IP:PORT> [flags]
+  ```
+
+## Command `check`
+
+  Check the status of Marbleruns control plane.
+  This command will check if the Marblerun coordinator and/or the Marblerun webhook are deployed on a Kubernetes cluster and wait until all replicas of the deployment have the `available` status.
+
+  **Usage**
+
+  ```bash
+  marblerun check
+  ```
+
+  **Flags**
+
+  {{<table "table table-striped table-bordered">}}
+  | Name, shorthand | Default | Description                                                             |
+  | --------------- | ------- | ----------------------------------------------------------------------- |
+  | --timeout       | 60      | Time to wait before aborting in seconds                                 |
+  {{</table>}}
+
 
 ## Command `install`
 
@@ -112,42 +178,6 @@ marblerun install [flags]
   Marblerun installed successfully
   ```
 
-
-## Command `status`
-
-Checks on the current status of the coordinator.
-
-**Usage**
-
-```bash
-marblerun status <IP:PORT> [flags]
-```
-
-**Flags**
-
-{{<table "table table-striped table-bordered">}}
-| Name, shorthand | Default | Description                                                                                                                      |
-| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| --era-config    |         | Path to remote attestation config file in json format, if none <br> provided the newest configuration will be loaded from github |
-| --help, -h      |         | help for status                                                                                                                  |
-| --insecure, -i  |         | Set to skip quote verification, needed when running in <br> simulation mode                                                      |
-{{</table>}}
-
-**Examples**
-
-```bash
-marblerun status $MARBLERUN
-```
-
-The output is similar to the following:
-
-```bash
-No era config file specified, getting latest config from github.com/edgelesssys/marblerun/releases/latest/download/coordinator-era.json
-Got latest config
-2: Coordinator is ready to accept a manifest.
-```
-
-
 ## Command `manifest`
 
 Set or update a manifest, or retrieve the signature of the manifest in place.
@@ -194,7 +224,6 @@ These flags apply to all sub commands of manifest
   Successfully verified coordinator, now uploading manifest
   Manifest successfully set, recovery data saved to: recovery-secret.json
   ```
-
 
 * ### `update`
 
@@ -276,113 +305,10 @@ These flags apply to all sub commands of manifest
   Note, that Internally, the coordinator handles the manifest in JSON format. Hence, the signature is always based on the JSON format of your manifest.
   You can quickly verify the integrity of the installed manifest by comparing the output of `marblerun manifest signature` on your local version and the signature returned by `marblerun manifest get` of the coordinator's version.
 
-## Command `recover`
-
-Recover the Marblerun coordinator from a sealed state by uploading a recovery key.
-For more information about coordinator recovery see [Recovery]({{< ref "docs/tasks/recover-coordinator.md" >}})
-
-**Usage**
-
-```bash
-marblerun recover <recovery_key_decrypted> <IP:PORT> [flags]
-```
-
-**Flags**
-
-{{<table "table table-striped table-bordered">}}
-| Name, shorthand | Default | Description                                                                                                                      |
-| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| --era-config    |         | Path to remote attestation config file in json format, if none <br> provided the newest configuration will be loaded from github |
-| --help, -h      |         | help for recover                                                                                                                 |
-| --insecure, -i  |         | Set to skip quote verification, needed when running in <br> simulation mode                                                      |
-{{</table>}}
-
-**Examples**
-
-```bash
-marblerun recover $MARBLERUN recovery_key_decrypted --era-config=era.json
-```
-
-The output is similar to the following:
-
-```bash
-Successfully verified coordinator, now uploading key
-Successfully uploaded recovery key and unsealed the Marblerun coordinator
-```
-
-## Command `certificate`
-
-Get the root and/or intermediate certificates of the Marblerun coordinator.
-
-**Flags**
-These flags apply to all sub commands of certificate
-
-{{<table "table table-striped table-bordered">}}
-| Name, shorthand | Default | Description                                                                                                                      |
-| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| --era-config    |         | Path to remote attestation config file in json format, if none <br> provided the newest configuration will be loaded from github |
-| --help, -h      |         | help for certificate                                                                                                             |
-| --insecure, -i  |         | simulation mode                                                                                                                  |
-| --output, -o    |         | File to save the certificate to                                                                                                  |
-{{</table>}}
-
-* ### `root`
-
-  Gets the root certificate of the Marblerun coordinator.
-
-  **Usage**
-
-  ```bash
-  marblerun certificate root <IP:PORT> [flags]
-  ```
-
-* ### `intermediate`
-
-  Gets the intermediate certificate of the Marblerun coordinator.
-
-  **Usage**
-
-  ```bash
-  marblerun certificate intermediate <IP:PORT> [flags]
-  ```
-
-* ### `chain`
-
-  Gets the certificate chain of the Marblerun coordinator.
-
-  **Usage**
-
-  ```bash
-  marblerun certificate chain <IP:PORT> [flags]
-  ```
-
-
-## Command `check`
-
-  Check the status of Marbleruns control plane.
-  This command will check if the Marblerun coordinator and/or the Marblerun webhook are deployed on a Kubernetes cluster and wait until all replicas of the deployment have the `available` status.
-
-  **Usage**
-  
-  ```bash
-  marblerun check
-  ```
-
-  **Flags**
-
-  {{<table "table table-striped table-bordered">}}
-  | Name, shorthand | Default | Description                                                             |
-  | --------------- | ------- | ----------------------------------------------------------------------- |
-  | --timeout       | 60      | Time to wait before aborting in seconds                                 |
-  {{</table>}}
-
-
-
 ## Command `namespace`
 
 Add namespaces to Marblerun.
 If the auto-injection feature is enabled. All new pods in those namespaces will get their Marblerun configuration automatically injected.
-
 
 * ### `add`
 
@@ -468,7 +394,7 @@ If the auto-injection feature is enabled. All new pods in those namespaces will 
     * `sgx.intel.com/enclave`
     * `sgx.intel.com/epc`
     * `sgx.intel.com/provision`
-  
+
 
   * [Azure SGX Device Plugin](https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-overview#azure-device-plugin-for-intel-sgx-), exposing the resource:
     * `kubernetes.azure.com/sgx_epc_mem_in_MiB`
@@ -480,7 +406,7 @@ If the auto-injection feature is enabled. All new pods in those namespaces will 
   ```
 
   * If your cluster does not support SGX the output is the following:
-  
+
   ```bash
   Cluster does not support SGX, you may still run Marblerun in simulation mode
   To install Marblerun run [marblerun install --simulation]
@@ -493,6 +419,73 @@ If the auto-injection feature is enabled. All new pods in those namespaces will 
   To install Marblerun run [marblerun install]
   ```
 
+## Command `recover`
+
+Recover the Marblerun coordinator from a sealed state by uploading a recovery key.
+For more information about coordinator recovery see [Recovery]({{< ref "docs/tasks/recover-coordinator.md" >}})
+
+**Usage**
+
+```bash
+marblerun recover <recovery_key_decrypted> <IP:PORT> [flags]
+```
+
+**Flags**
+
+{{<table "table table-striped table-bordered">}}
+| Name, shorthand | Default | Description                                                                                                                      |
+| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| --era-config    |         | Path to remote attestation config file in json format, if none <br> provided the newest configuration will be loaded from github |
+| --help, -h      |         | help for recover                                                                                                                 |
+| --insecure, -i  |         | Set to skip quote verification, needed when running in <br> simulation mode                                                      |
+{{</table>}}
+
+**Examples**
+
+```bash
+marblerun recover $MARBLERUN recovery_key_decrypted --era-config=era.json
+```
+
+The output is similar to the following:
+
+```bash
+Successfully verified coordinator, now uploading key
+Successfully uploaded recovery key and unsealed the Marblerun coordinator
+```
+
+## Command `status`
+
+Checks on the current status of the coordinator.
+
+**Usage**
+
+```bash
+marblerun status <IP:PORT> [flags]
+```
+
+**Flags**
+
+{{<table "table table-striped table-bordered">}}
+| Name, shorthand | Default | Description                                                                                                                      |
+| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| --era-config    |         | Path to remote attestation config file in json format, if none <br> provided the newest configuration will be loaded from github |
+| --help, -h      |         | help for status                                                                                                                  |
+| --insecure, -i  |         | Set to skip quote verification, needed when running in <br> simulation mode                                                      |
+{{</table>}}
+
+**Examples**
+
+```bash
+marblerun status $MARBLERUN
+```
+
+The output is similar to the following:
+
+```bash
+No era config file specified, getting latest config from github.com/edgelesssys/marblerun/releases/latest/download/coordinator-era.json
+Got latest config
+2: Coordinator is ready to accept a manifest.
+```
 
 ## Command `uninstall`
 
@@ -523,7 +516,7 @@ If the auto-injection feature is enabled. All new pods in those namespaces will 
   The output is similar to the following:
 
   ```
-  CLI Version: v0.3.0 
+  CLI Version: v0.3.0
   Commit: 689787ea6f3ea3e047a68e2d4deaf095d1d84db9
   Coordinator Version: v0.3.0
   ```

--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -61,7 +61,7 @@ Use "marblerun [command] --help" for more information about a command.
 Get the root and/or intermediate certificates of the Marblerun coordinator.
 
 **Flags**
-These flags apply to all sub commands of certificate
+These flags apply to all `certificate` subcommands
 
 {{<table "table table-striped table-bordered">}}
 | Name, shorthand | Default | Description                                                                                                                      |
@@ -123,15 +123,22 @@ These flags apply to all sub commands of certificate
 
 
 ## Command `graphene-prepare`
-Takes a Graphene manifest template, automatically performs changes and downloads the Marblerun premain so that your application can be used in combination with Marblerun with less effort. See [Building a service: Graphene]({{< ref "docs/tasks/build-service-graphene.md" >}}) for more information.
+This command helps you if you want to add Graphene-based services to your Marblerun service mesh.
+It prepares your Graphene project to be used as a Marble.
+Given your [Graphene manifest template](https://graphene.readthedocs.io/en/latest/manifest-syntax.html), it will suggest the required adjustments needed and adds our bootstrapping data-plane code to your Graphene image.
+See [Building a service: Graphene]({{< ref "docs/tasks/build-service-graphene.md" >}}) for detailed information on Marblerun’s Graphene integration and our changes in your Graphene manifest.
 
-Please note that this only works on a best-effort basis and may not instantly work correctly. While suggestions should be made for every valid TOML Graphene configuration, changes can only performed for non-hierarchically sorted configurations. as the official Graphene examples. Plus, you need to create a Marblerun manifest in addition by yourself. The unmodified manifest is saved as a backup under the old path with an added ".bak" suffix, allowing you to try out and rollback any changes performed.
+Please note that this only works on a best-effort basis and may not instantly work correctly.
+While suggestions should be made for every valid TOML Graphene configuration, changes can only be performed for non-hierarchically sorted configurations. as the official Graphene examples.
+The unmodified manifest is saved as a backup under the old path with an added ".bak" suffix, allowing you to try out and roll back any changes performed.
+
+Remember, you need to create a [Marblerun manifest]({{< ref "docs/tasks/define-manifest.md" >}}) in addition to the Graphene manifest. Adding Graphene packages to your manifest is straightforward and follows the same principles as any other SGX enclave.
 
 This command supports two modes, **spawn** and **preload**.
 
 * **`spawn`**
 
-  Replaces the original entrypoint of your application with the premain process which eventually spawns your application. Dedicates argv provisioning to Marblerun, so make sure your Marblerun manifest is designed to supply the arguments correctly, otherwise you might run into issues when Graphene handled the arguments for it before.
+  Replaces the original entrypoint of your application with the bootstrapping Marble premain process which eventually spawns your application. Dedicates argv provisioning to Marblerun. If you configured the arguments to your Graphene application through the [Graphene manifest](https://graphene.readthedocs.io/en/latest/manifest-syntax.html#command-line-arguments) before, you need to transfer those to the [Marblerun manifest]({{< ref "docs/tasks/define-manifest.md#manifestmarbles">}}).
 
   **Usage**
 
@@ -169,7 +176,7 @@ This command supports two modes, **spawn** and **preload**.
 
 * **`preload`**
 
-  Adds the premain as a shared library loaded on launch of your application via LD_PRELOAD. Allows for a faster launch than `spawn` and delegates more features to Graphene (but restricts Marblerun's functionalities), making it the quickest way to adapt your existing application. However, features such as argv provisioning cannot be used in Marblerun anymore in this mode.
+  Adds the premain as a shared library loaded during the launch of your application via LD_PRELOAD. Allows for a faster launch than `spawn` and delegates more features to Graphene (but restricts Marblerun's functionalities), making it the quickest way to adapt your existing application. However, features such as argv provisioning cannot be used in Marblerun anymore in this mode.
 
   **Usage**
   ```bash

--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -38,18 +38,18 @@ Usage:
   marblerun [command]
 
 Available Commands:
-  certificate Retrieves the certificate of the Marblerun coordinator
-  check       Check the status of Marbleruns control plane
+  certificate      Retrieves the certificate of the Marblerun coordinator
+  check            Check the status of Marbleruns control plane
   graphene-prepare Modifies a Graphene manifest for use with Marblerun
-  help        Help about any command
-  install     Installs marblerun on a kubernetes cluster
-  manifest    Manages manifest for the Marblerun coordinator
-  namespace   Manages namespaces associated with Marblerun installations
-  precheck    Check if your kubernetes cluster supports SGX
-  recover     Recovers the Marblerun coordinator from a sealed state
-  status      Gives information about the status of the marblerun Coordinator
-  uninstall   Removes Marblerun from a kubernetes cluster
-  version     Display version of this CLI and (if running) the Marblerun coordinator
+  help             Help about any command
+  install          Installs marblerun on a kubernetes cluster
+  manifest         Manages manifest for the Marblerun coordinator
+  namespace        Manages namespaces associated with Marblerun installations
+  precheck         Check if your kubernetes cluster supports SGX
+  recover          Recovers the Marblerun coordinator from a sealed state
+  status           Gives information about the status of the marblerun Coordinator
+  uninstall        Removes Marblerun from a kubernetes cluster
+  version          Display version of this CLI and (if running) the Marblerun coordinator
 
 Flags:
   -h, --help   help for marblerun


### PR DESCRIPTION
This PR:

- updates the available commands with the ones currently available 
- sorts the commands alphabetically 
- adds documentation for `graphene-prepare`

It's quite a bit more text for `graphene-prepare` than for some other commands. However, I think it is needed in a way because it is someway half between "magic" but also "only works under certain circumstances".
