### PR TITLE
Update quickstart to use check and precheck commands

### DIFF
--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -39,12 +39,16 @@ Usage:
 
 Available Commands:
   certificate Retrieves the certificate of the Marblerun coordinator
+  check       Check the status of Marbleruns control plane
   help        Help about any command
   install     Installs marblerun on a kubernetes cluster
   manifest    Manages manifest for the Marblerun coordinator
   namespace   Manages namespaces associated with Marblerun installations
+  precheck    Check if your kubernetes cluster supports SGX
   recover     Recovers the Marblerun coordinator from a sealed state
   status      Gives information about the status of the marblerun Coordinator
+  uninstall   Removes Marblerun from a kubernetes cluster
+  version     Display version of this CLI and (if running) the Marblerun coordinator
 
 Flags:
   -h, --help   help for marblerun
@@ -161,7 +165,7 @@ These flags apply to all sub commands of manifest
 
 * ### `set`
 
-  Uploads a manifest in json format to the Marblerun coordinator.
+  Uploads a manifest in json or yaml format to the Marblerun coordinator.
   If a recovery key was set in the manifest, a recovery secret will be sent back.
 
   **Usage**
@@ -257,6 +261,21 @@ These flags apply to all sub commands of manifest
   Manifest written to: manifest-signature.json
   ```
 
+* ### `signature`
+
+  Print the signature of a Marblerun manifest.
+  The manifest can be in either json or yaml format.
+
+  **Usage**
+
+  ```bash
+  marblerun manifest signature manifest.json
+  ```
+
+  The output is the sha256 hash in base64 encoding of the manifest as it would be interpreted by the Marblerun coordinator.
+  Note, that Internally, the coordinator handles the manifest in JSON format. Hence, the signature is always based on the JSON format of your manifest.
+  You can quickly verify the integrity of the installed manifest by comparing the output of `marblerun manifest signature` on your local version and the signature returned by `marblerun manifest get` of the coordinator's version.
+
 ## Command `recover`
 
 Recover the Marblerun coordinator from a sealed state by uploading a recovery key.
@@ -336,6 +355,27 @@ These flags apply to all sub commands of certificate
   ```bash
   marblerun certificate chain <IP:PORT> [flags]
   ```
+
+
+## Command `check`
+
+  Check the status of Marbleruns control plane.
+  This command will check if the Marblerun coordinator and/or the Marblerun webhook are deployed on a Kubernetes cluster and wait until all replicas of the deployment have the `available` status.
+
+  **Usage**
+  
+  ```bash
+  marblerun check
+  ```
+
+  **Flags**
+
+  {{<table "table table-striped table-bordered">}}
+  | Name, shorthand | Default | Description                                                             |
+  | --------------- | ------- | ----------------------------------------------------------------------- |
+  | --timeout       | 60      | Time to wait before aborting in seconds                                 |
+  {{</table>}}
+
 
 
 ## Command `namespace`
@@ -419,6 +459,40 @@ If the auto-injection feature is enabled. All new pods in those namespaces will 
   testspace
   ```
 
+## Command `precheck`
+
+  Check if your kubernetes cluster supports SGX.
+  More precisely the command will check if any nodes in the cluster define SGX resources through the use of [Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/).
+  Currently supported are:
+  * [Intel SGX Device Plugin](https://intel.github.io/intel-device-plugins-for-kubernetes/cmd/sgx_plugin/README.html), exposing the resources:
+    * `sgx.intel.com/enclave`
+    * `sgx.intel.com/epc`
+    * `sgx.intel.com/provision`
+  
+
+  * [Azure SGX Device Plugin](https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-overview#azure-device-plugin-for-intel-sgx-), exposing the resource:
+    * `kubernetes.azure.com/sgx_epc_mem_in_MiB`
+
+  **Usage**
+
+  ```bash
+  marblerun precheck
+  ```
+
+  * If your cluster does not support SGX the output is the following:
+  
+  ```bash
+  Cluster does not support SGX, you may still run Marblerun in simulation mode
+  To install Marblerun run [marblerun install --simulation]
+  ```
+
+  * If you cluster does support SGX the output is similar to the following
+
+  ```bash
+  Cluster supports SGX on 2 nodes
+  To install Marblerun run [marblerun install]
+  ```
+
 
 ## Command `uninstall`
 
@@ -434,4 +508,22 @@ If the auto-injection feature is enabled. All new pods in those namespaces will 
   The output is the following:
   ```bash
   Marblerun successfully removed from your cluster
+  ```
+
+## Command `version`
+
+  Display version information of CLI, and the Marblerun coordinator running on a Kubernetes cluster.
+
+  **Usage**
+
+  ```bash
+  marblerun version
+  ```
+
+  The output is similar to the following:
+
+  ```
+  CLI Version: v0.3.0 
+  Commit: 689787ea6f3ea3e047a68e2d4deaf095d1d84db9
+  Coordinator Version: v0.3.0
   ```

--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -68,12 +68,12 @@ marblerun install [flags]
 {{<table "table table-striped table-bordered">}}
 | Name, shorthand          | Default   | Description                                                                                           |
 | :----------------------- | :-------- | :---------------------------------------------------------------------------------------------------- |
-| --client-server-port     | 25555     | Set the client server port. Needs to be configured to the same <br> port as in your client tool stack |
+| --client-server-port     | 4433     | Set the client server port. Needs to be configured to the same <br> port as in your client tool stack |
 | --disable-auto-injection |           | Disable automatic injection of selected namespaces                                                    |
 | --domain                 | localhost | Sets the CNAME for the coordinator certificate                                                        |
 | --help, -h               |           | help for install                                                                                      |
 | --marblerun-chart-path   |           | Path to marblerun helm chart                                                                          |
-| --mesh-sever-port        | 25554     | Set the mesh server port. Needs to be configured to the same <br> port as in the data-plane marbles   |
+| --mesh-sever-port        | 2001     | Set the mesh server port. Needs to be configured to the same <br> port as in the data-plane marbles   |
 | --no-sgx-device-plugin   |           | Disables the installation of an sgx device plugin                                                     |
 | --simulation             |           | Set Marblerun to start in simulation mode, needed when not <br> running on an SGX enabled cluster     |
 {{</table>}}

--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -59,8 +59,8 @@ git clone https://github.com/edgelesssys/emojivoto.git && cd emojivoto
 Get the Coordinator's address and set the DNS
 
 ```bash
-kubectl -n marblerun port-forward svc/coordinator-client-api 25555:25555 --address localhost >/dev/null &
-export MARBLERUN=localhost:25555
+kubectl -n marblerun port-forward svc/coordinator-client-api 4433:4433 --address localhost >/dev/null &
+export MARBLERUN=localhost:4433
 ```
 
 Verify the Quote and get the Coordinator's Root-Certificate. The SGX Quote proofs the integrity of the coordinator pod. Marblerun returns a certificate as result and stores it as marblerun.cert in your current directory. The Certificate is bound to the Quote and can be used for future verification. Since we are not using SGX hardware in this case, the quote is omitted by marblerun.

--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -43,9 +43,10 @@ Deploy Marblerun's Coordinator to the Minikube cluster using the CLI.
 marblerun install --domain=localhost --simulation
 ```
 
-You can now find the Marblerun Coordinator Pod deployed on your cluster using kubectl:
+Wait for Marblerun to start:
+
 ```bash
-kubectl get pods -n marblerun
+marblerun check
 ```
 
 ## Step 2: Pull the demo application
@@ -124,12 +125,24 @@ sudo wget -O /usr/local/bin/marblerun https://github.com/edgelesssys/marblerun/r
 sudo chmod +x /usr/local/bin/marblerun
 ```
 
+### Verify the cluster supports SGX
+```bash
+marblerun precheck
+```
+If the command reports your cluster does not support SGX verify the cluster was deployed correctly as described in [this guide](https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-get-started) or consider following the [First Steps on Minikube]({{< ref "docs/getting-started/quickstart.md#first-steps-on-minikube" >}}).
+
 ## Step 1: Deploy the Coordinator onto the cluster
 
-Deploy Marblerun's Coordinator to the Minikube cluster using the CLI. Update the domain parameter with your cluster's domain name.
+Deploy Marblerun's Coordinator to the Kubernetes cluster using the CLI. Update the domain parameter with your cluster's domain name.
 
 ```bash
 marblerun install --domain=mycluster.uksouth.cloudapp.azure.com
+```
+
+Wait for Marblerun to start:
+
+```bash
+marblerun check
 ```
 
 ## Step 2: Pull the demo application

--- a/content/docs/tasks/add-service.md
+++ b/content/docs/tasks/add-service.md
@@ -60,12 +60,12 @@ Now you can define with which parameters (i.e., files, environments variables, a
 When you start your service, you need to pass in a couple of configuration parameters through environment variables. Here is an example:
 
 ```bash
-EDG_MARBLE_COORDINATOR_ADDR=coordinator-mesh-api.marblerun:25554 EDG_MARBLE_TYPE=mymarble EDG_MARBLE_UUID_FILE=$PWD/uuid EDG_MARBLE_DNS_NAMES=localhost,myservice erthost enclave.signed
+EDG_MARBLE_COORDINATOR_ADDR=coordinator-mesh-api.marblerun:2001 EDG_MARBLE_TYPE=mymarble EDG_MARBLE_UUID_FILE=$PWD/uuid EDG_MARBLE_DNS_NAMES=localhost,myservice erthost enclave.signed
 ```
 
 `erthost` is the generic host for Marbles, which will load your `enclave.signed`. The environment variables have the following purposes.
 
-* `EDG_MARBLE_COORDINATOR_ADDR` is the network address of the Coordinator's API for Marbles. When you deploy the Coordinator using our Helm repository as is described [here]({{< ref "docs/tasks/deploy.md" >}}), the default address is `coordinator-mesh-api.marblerun:25554`.
+* `EDG_MARBLE_COORDINATOR_ADDR` is the network address of the Coordinator's API for Marbles. When you deploy the Coordinator using our Helm repository as is described [here]({{< ref "docs/tasks/deploy.md" >}}), the default address is `coordinator-mesh-api.marblerun:2001`.
 
 * `EDG_MARBLE_TYPE` needs to reference one entry from your Manifest's `Marbles` section.
 
@@ -110,7 +110,7 @@ spec:
     containers:
     - env:
     - name: EDG_MARBLE_COORDINATOR_ADDR
-        value: coordinator-mesh-api.marblerun:25554
+        value: coordinator-mesh-api.marblerun:2001
     - name: EDG_MARBLE_TYPE
         value: web
     - name: EDG_MARBLE_DNS_NAMES

--- a/content/docs/tasks/deploy.md
+++ b/content/docs/tasks/deploy.md
@@ -72,9 +72,9 @@ Update the hostname with your cluster's FQDN.
 
 ## Accessing the client API
 
-The coordinator creates a [`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) service called `coordinator-client-api` exposing the client API on the default port 25555.
+The coordinator creates a [`LoadBalancer`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) service called `coordinator-client-api` exposing the client API on the default port 4433.
 Depending on your cloud provider you can provision a LoadBalancer that exposes this service to the outside world or you deploy an Ingress Gateway forwarding the traffic.
-If you are running with Minikube you can expose this service to localhost with `kubectl -n marblerun port-forward svc/coordinator-client-api 25555:25555 --address localhost`.
+If you are running with Minikube you can expose this service to localhost with `kubectl -n marblerun port-forward svc/coordinator-client-api 4433:4433 --address localhost`.
 
 ## Ingress/Gateway configuration
 

--- a/themes/marblerun/layouts/partials/header.html
+++ b/themes/marblerun/layouts/partials/header.html
@@ -19,7 +19,7 @@
         <a class="nav-link {{ if eq .Title " Community" }}active{{ end }}" href="/community"><i class="fas fa-comments"></i>&nbsp;Community</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/edgelesssys/marblerun"> <i class="fab fa-github"></i>&nbsp;Github</a>
+        <a class="nav-link" href="https://github.com/edgelesssys/marblerun"> <i class="fab fa-github"></i>&nbsp;GitHub</a>
       </li>
       <li class="nav-item">
         <a href="/docs/getting-started/quickstart" class="nav-link btn btn-primary ml-3">Get started →</a>


### PR DESCRIPTION
Adds the usage of `check` in both `First steps on Minikube` and `First steps on AKS` instead of manually waiting and checking with `kubectl`.
Also adds a step in `First steps on AKS` using the `precheck` command to verify the cluster supports SGX