### PR TITLE
Use wget -O consistently

### DIFF
--- a/content/docs/getting-started/cli.md
+++ b/content/docs/getting-started/cli.md
@@ -13,7 +13,7 @@ To install the Marblerun CLI on your machine you can use our pre-built binaries.
 ### For the current user
 
 ```bash
-wget -P ~/.local/bin/marblerun https://github.com/edgelesssys/marblerun/releases/latest/download/marblerun
+wget -P ~/.local/bin https://github.com/edgelesssys/marblerun/releases/latest/download/marblerun
 chmod +x ~/.local/bin/marblerun
 ```
 

--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -40,7 +40,7 @@ To install the CLI manually, run:
 ### For the current user
 
 ```bash
-wget -P ~/.local/bin/marblerun https://github.com/edgelesssys/marblerun/releases/latest/download/marblerun
+wget -P ~/.local/bin https://github.com/edgelesssys/marblerun/releases/latest/download/marblerun
 chmod +x ~/.local/bin/marblerun
 ```
 


### PR DESCRIPTION
We can either use -P with a prefix or -O with the complete path.
Mixing them led to using `-P` incorrectly.