### PR TITLE
Add mention of az-dcap-client dependency

### DIFF
--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -57,17 +57,6 @@ Once installed, verify the CLI is running correctly with:
 marblerun
 ```
 
-### Attestation requirements
-
-To verify remote SGX reports, the CLI relies on the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client).
-If you plan to use marblerun outside of simulation mode you need to install the client:
-```bash
-echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
-wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-sudo apt update
-sudo apt -y install az-dcap-client
-```
-
 ## Step 2: Install the control-plane onto your cluster
 
 Now that you have the CLI running locally and a cluster that is ready to go, it’s time to install the control plane.

--- a/content/docs/getting-started/quickstart.md
+++ b/content/docs/getting-started/quickstart.md
@@ -57,6 +57,17 @@ Once installed, verify the CLI is running correctly with:
 marblerun
 ```
 
+### Attestation requirements
+
+To verify remote SGX reports, the CLI relies on the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client).
+If you plan to use marblerun outside of simulation mode you need to install the client:
+```bash
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+sudo apt update
+sudo apt -y install az-dcap-client
+```
+
 ## Step 2: Install the control-plane onto your cluster
 
 Now that you have the CLI running locally and a cluster that is ready to go, it’s time to install the control plane.

--- a/content/docs/reference/cli.md
+++ b/content/docs/reference/cli.md
@@ -12,6 +12,17 @@ This CLI allows you to install Marblerun on your cluster and interacts with the 
 {{< toc >}}
 ## Installation
 
+### Requirements
+
+For quote verificiation the CLI relies on the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client).
+To install the dependency run:
+```bash
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+sudo apt update
+sudo apt -y install az-dcap-client
+```
+
 To install the Marblerun CLI on your machine you can use our pre-built binaries.
 
 **For the current user**
@@ -37,7 +48,7 @@ go build -o marblerun github.com/edgelesssys/marblerun/cli
 To list all available commands, either run `marblerun` with no commands or execute `marblerun help`
 The output is the following:
 
-```bash
+```
 Usage:
   marblerun [command]
 

--- a/content/docs/reference/cli.md
+++ b/content/docs/reference/cli.md
@@ -12,17 +12,6 @@ This CLI allows you to install Marblerun on your cluster and interacts with the 
 {{< toc >}}
 ## Installation
 
-### Requirements
-
-For quote verificiation the CLI relies on the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client).
-To install the dependency run:
-```bash
-echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
-wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-sudo apt update
-sudo apt -y install az-dcap-client
-```
-
 To install the Marblerun CLI on your machine you can use our pre-built binaries.
 
 **For the current user**
@@ -72,6 +61,18 @@ Flags:
 
 Use "marblerun [command] --help" for more information about a command.
 ```
+
+### Requirements
+
+If the coordinator is running on an Azure VM, the CLI relies on the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client) to verify quotes.
+To install the dependency run:
+```bash
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+sudo apt update
+sudo apt -y install az-dcap-client
+```
+
 ## Command `certificate`
 
 Get the root and/or intermediate certificates of the Marblerun coordinator.


### PR DESCRIPTION
Adds mentions of Azure DCAP client requirements to the docs.

I'm not certain if we need to mention it in the quickstart section, since the cli should work fine in simulation mode, even without the dcap client installed.