### PR TITLE
AB#1058 add update log

### DIFF
--- a/content/docs/reference/cli.md
+++ b/content/docs/reference/cli.md
@@ -388,10 +388,44 @@ These flags apply to all subcommands of manifest
   }
   ```
 
+* ### `log`
+
+  Retrieves a structured log of updates to the manifest. This allows users to easily check what the currently supported security versions are and if certain secrets have been set by another user.
+
+  **Usage**
+
+  ```bash
+  marblerun manifest log <IP:PORT> [flags]
+  ```
+
+  **Flags**
+
+  {{<table "table table-striped table-bordered">}}
+  | Name, shorthand | Default | Description                                    |
+  | --------------- | --------| ---------------------------------------------- |
+  | --output, -o    |         | Save log to file instead of printing to stdout |
+  {{</table>}}
+
+  **Examples**
+
+  ```bash
+  marblerun manifest log $MARBLERUN
+  ```
+
+  The output is similar to the following:
+  ```
+  Successfully verified coordinator, now requesting update log
+  Update log:
+  {"time":"2021-07-01T09:10:23.128Z","update":"initial manifest set"}
+  {"time":"2021-07-01T09:32:54.207Z","update":"secret set","user":"admin","secret":"symmetric_key_unset","type":"symmetric-key"}
+  {"time":"2021-07-01T09:32:54.207Z","update":"secret set","user":"admin","secret":"cert_unset","type":"cert-ed25519"}
+  {"time":"2021-07-01T10:05:44.791Z","update":"SecurityVersion increased","user":"admin","package":"world","new version":4}
+  ```
+
 * ### `signature`
 
   Print the signature of a Marblerun manifest.
-  The manifest can be in either json or yaml format.
+  The manifest can be in either JSON or YAML format.
 
   **Usage**
 
@@ -401,7 +435,32 @@ These flags apply to all subcommands of manifest
 
   The output is the sha256 hash in base64 encoding of the manifest as it would be interpreted by the Marblerun coordinator.
   Note, that Internally, the coordinator handles the manifest in JSON format. Hence, the signature is always based on the JSON format of your manifest.
-  You can quickly verify the integrity of the installed manifest by comparing the output of `marblerun manifest signature` on your local version and the signature returned by `marblerun manifest get` of the coordinator's version.
+
+* ### `verify`
+  Verifies that the signature returned by the Coordinator is equal to a local signature.
+  Can be used to quickly verify the integrity of the installed manifest.
+  You can provide a signature directly, or a manifest in either JSON or YAML format.
+
+  **Usage**
+
+  ```bash
+  marblerun manifest verify <manifest/signature> <IP:PORT> [flags]
+  ```
+
+  **Examples**
+
+  ```bash
+  marblerun manifest verify manifest.json $MARBLERUN
+  ```
+
+  ```bash
+  marblerun manifest verify 152493c4a85845480a04b95f79dd447a4573862e0d2c102c71b91b8b3cbcade5 $MARBLERUN
+  ```
+
+  If the signatures match, the output is the following:
+  ```bash
+  OK
+  ```
 
 ## Command `namespace`
 

--- a/content/docs/reference/coordinator.md
+++ b/content/docs/reference/coordinator.md
@@ -48,9 +48,8 @@ For deploying and verifying the Manifest.
 * Before deploying the application to the cluster the manifest needs to be set once by the provider
 * Users can retrieve and inspect the manifest through this endpoint before interacting with the application
 
-**Returns (HTTP GET)**:
-
-
+##### GET
+**Returns**:
 {{<table "table table-striped table-bordered">}}
 | Field value       | Type   | Description                                                                                              |
 | ----------------- | ------ | -------------------------------------------------------------------------------------------------------- |
@@ -58,8 +57,8 @@ For deploying and verifying the Manifest.
 | Manifest          | bytes  | The currently set manifest in base64 encoding. Does not change when an Update Manifest has been applied. |
 {{</table>}}
 
-**Returns (HTTP POST)**:
-
+##### POST
+**Returns**:
 {{<table "table table-striped table-bordered">}}
 | Field value     | Type             | Description                                                                                                                                                                                                |
 | --------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -84,7 +83,8 @@ For retrieving a remote attestation quote over the whole cluster and the root ce
 The quote is an SGX-DCAP quote, you can learn more about DCAP in the [official Intel DCAP orientation](https://download.01.org/intel-sgx/sgx-dcap/1.9/linux/docs/Intel_SGX_DCAP_ECDSA_Orientation.pdf).
 Both the provider and the users of the confidential application can use this endpoint to verify the integrity of the Coordinator and the cluster at any time.
 
-**Returns (HTTP GET)**:
+##### GET
+**Returns**:
 {{<table "table table-striped table-bordered">}}
 | Field value | Type   | Description                                                                                                                                                               |
 | ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -126,6 +126,8 @@ wget https://github.com/edgelesssys/marblerun/releases/latest/download/coordinat
 
 For recovering the Coordinator in case unsealing the existing state failed.
 
+##### POST
+
 This API endpoint is only available when the coordinator is in recovery mode. Before you can use the endpoint, you need to decrypt the recovery secret which you may have received when setting the manifest initially. See [Recovering the Coordinator]({{< ref "docs/workflows/recover-coordinator.md" >}}) to retrieve the recovery key needed to use this API endpoint correctly.
 
 Example for recovering the coordinator:
@@ -140,7 +142,8 @@ For setting and retrieving secrets.
 
 This API endpoint only works when `Users` were defined in the Manifest. For more information, look up [Managing secrets]({{< ref "docs/workflows/managing-secrets.md" >}}).
 
-**Returns (HTTP GET)**:
+##### GET
+**Returns**:
 {{<table "table table-striped table-bordered">}}
 | Field value                 | Type   | Description                                                      |
 | --------------------------- | ------ | ---------------------------------------------------------------- |
@@ -158,6 +161,7 @@ Example for retrieving the secrets `symmetric_key_shared` and `cert_shared`:
 curl --cacert marblerun.crt --cert user_certificate.crt --key user_private.key https://$MARBLERUN/secrets?s=symmetric_key_shared&s=cert_shared
 ```
 
+##### POST
 Setting secrets requires uploading them in JSON format using a POST request. For more information refer to [Managing secrets]({{< ref "docs/workflows/managing-secrets.md" >}}).
 
 Example for setting secrets from the file `secrets.json`:
@@ -169,7 +173,8 @@ curl --cacert marblerun.crt --cert user_certificate.crt --key user_private.key -
 
 For returning the current state of the coordinator.
 
-**Returns (HTTP GET)**:
+##### GET
+**Returns**:
 {{<table "table table-striped table-bordered">}}
 | Field value   | Type   | Description                                                                                       |
 | ------------- | ------ | ------------------------------------------------------------------------------------------------- |
@@ -197,8 +202,19 @@ It may be useful to use this API endpoint and use it for other monitoring tools.
 
 ### /update
 
-For updating the packages specified in the currently set Manifest.
+For updating the packages specified in the currently set Manifest or retrieving a log of all performed updates.
 
+##### GET
+**Returns:**
+
+A structured log of all updates performed via the `/update` or `/secrets` endpoint, including timestamp, author, and affected resources.
+
+Example for getting the update log:
+```bash
+curl -k "https://$MARBLERUN/update"
+```
+
+##### POST
 This API endpoint only works when `Users` were defined in the Manifest. For more information, look up [Updating a Manifest]({{< ref "docs/workflows/update-manifest.md" >}})
 
 Example for updating the manifest:


### PR DESCRIPTION
Adds the update log feature to the docs.
This PR also contains a small update to the `manifest signature` command and adds the previously missing `manifest verify` command.

I have also made a small change to the way the coordinator client api reference is structured.
Each endpoint now specifies if it requires a `POST` or `GET` request.
Previously this was only shown if an endpoint returned some value over that endpoint

Current:
```markdown
### /endpoint
***Returns (HTTP GET):***
<table containing information about return values on GET>
Some text describing the GET endpoint

Some text describing the POST endpoint, which does not return anything
```

New:
```markdown
### /endpoint
##### GET
***Returns:***
<table containing information about return values on GET>
Some text describing the GET endpoint

##### POST
Some text describing the POST endpoint, which does not return anything
```